### PR TITLE
Feature/79 clear saveforlater forms when they already exist in db

### DIFF
--- a/src/app/irf/list/irfList.controller.js
+++ b/src/app/irf/list/irfList.controller.js
@@ -106,13 +106,26 @@ export default class IrfListController {
     }
 
     checkForExistingIrfs() {
-        var savedForLaterIrfs = Object.keys(JSON.parse(localStorage.getItem('saved-irfs')));
-        console.log(savedForLaterIrfs);
-        if (savedForLaterIrfs) {
-            savedForLaterIrfs.forEach((irfNumber) => {
-                console.log(irfNumber);
-                this.service.irfExists(irfNumber);
+        var savedForLaterIrfs = this.getSaveForLaterObject();
+        if (savedForLaterIrfs == null) return;
+
+        savedForLaterIrfs = Object.keys(savedForLaterIrfs);
+        savedForLaterIrfs.forEach((irfNumber) => {
+            this.service.irfExists(irfNumber).then((promise) => {
+                if (promise.data == irfNumber) {
+                    this.removeIrfFromSaveForLater(irfNumber);
+                }
             });
-        }
+        });
+    }
+
+    removeIrfFromSaveForLater(irfNumber) {
+        var obj = this.getSaveForLaterObject();
+        delete obj[irfNumber];
+        localStorage.setItem('saved-irfs', JSON.stringify(obj));
+    }
+
+    getSaveForLaterObject() {
+        return JSON.parse(localStorage.getItem('saved-irfs'));
     }
 }

--- a/src/app/irf/list/irfList.controller.js
+++ b/src/app/irf/list/irfList.controller.js
@@ -25,6 +25,8 @@ export default class IrfListController {
             this.queryParameters.search = $stateParams.search;
         }
         this.getIrfList();
+
+        this.checkForExistingIrfs();
     }
 
     transform(queryParams) {
@@ -100,6 +102,17 @@ export default class IrfListController {
         }
         else {
             irf.confirmedDelete = true;
+        }
+    }
+
+    checkForExistingIrfs() {
+        var savedForLaterIrfs = Object.keys(JSON.parse(localStorage.getItem('saved-irfs')));
+        console.log(savedForLaterIrfs);
+        if (savedForLaterIrfs) {
+            savedForLaterIrfs.forEach((irfNumber) => {
+                console.log(irfNumber);
+                this.service.irfExists(irfNumber);
+            });
         }
     }
 }

--- a/src/app/irf/list/irfList.controller.spec.js
+++ b/src/app/irf/list/irfList.controller.spec.js
@@ -18,7 +18,8 @@ describe('IRF List Controller',() => {
         MockIrfListService = jasmine.createSpyObj('IrfListService', [
             'getIrfList',
             'getMoreIrfs',
-            'deleteIrf'
+            'deleteIrf',
+            'irfExists'
         ]);
 
         let response = {'data':{
@@ -36,6 +37,14 @@ describe('IRF List Controller',() => {
             };
         });
 
+        MockIrfListService.irfExists.and.callFake( () => {
+            return {
+                then: (f) => {
+                    f({data: "BHD123"});
+                }
+            };
+        });
+
         vm = new IrfListController(MockIrfListService, MockSessionService, $stateParams, $timeout, $window, {}, {BaseUrl: "asdf"});
     }));
 
@@ -48,6 +57,12 @@ describe('IRF List Controller',() => {
             $stateParams = {};
             vm = new IrfListController(MockIrfListService, MockSessionService, $stateParams, $timeout, $window, {}, {BaseUrl: "asdf"});
             expect(vm.queryParameters.search).not.toBe(null);
+        });
+
+        it('expect checkForExistingIrfs to be called', () => {
+            spyOn(vm, 'checkForExistingIrfs');
+            vm.constructor(MockIrfListService, MockSessionService, $stateParams, $timeout, $window, {}, {BaseUrl: "asdf"});
+            expect(vm.checkForExistingIrfs).toHaveBeenCalled();
         });
     });
 
@@ -160,6 +175,59 @@ describe('IRF List Controller',() => {
             vm.updateSort('rf_number');
             expect(vm.queryParameters.reverse).toBe(false);
             expect(vm.queryParameters.ordering).toBe('rf_number');
+        });
+    });
+
+    describe('function checkForExistingIrfs', () => {
+        let savedIrfs;
+        beforeEach(() => {
+            savedIrfs = {
+                BHD123: {asdf: "asdf"},
+                BHD1234: {asdf: "asdf"}
+            }
+            localStorage.setItem('saved-irfs', JSON.stringify(savedIrfs));
+        });
+
+        it('should return undefined if no saved-irfs', () => {
+            localStorage.removeItem('saved-irfs');
+            var result = vm.checkForExistingIrfs();
+
+            expect(result).toEqual(undefined);
+        });
+
+        it('should call irfExists on each form in savedIrfs', () => {
+            var result = vm.checkForExistingIrfs();
+
+            expect(vm.service.irfExists).toHaveBeenCalledWith('BHD123');
+            expect(vm.service.irfExists).toHaveBeenCalledWith('BHD1234');
+        });
+
+        it('should call removeIrfFromSaveForLater on response with same name', () => {
+            spyOn(vm, 'removeIrfFromSaveForLater');
+
+            var result = vm.checkForExistingIrfs();
+
+            expect(vm.removeIrfFromSaveForLater).toHaveBeenCalledWith('BHD123');
+            expect(vm.removeIrfFromSaveForLater).not.toHaveBeenCalledWith('BHD1234');
+        });
+    });
+
+    describe('function removeIrfFromSaveForLater', () => {
+        let savedIrfs;
+        beforeEach(() => {
+            savedIrfs = {
+                BHD123: {asdf: "asdf"},
+                BHD1234: {asdf: "asdf"}
+            }
+            localStorage.setItem('saved-irfs', JSON.stringify(savedIrfs));
+        });
+
+        it('Should remove object with passed in parameter from local storage', () => {
+            expect(savedIrfs).toEqual(JSON.parse(localStorage.getItem('saved-irfs')));
+
+            vm.removeIrfFromSaveForLater('BHD123');
+
+            expect(savedIrfs).not.toEqual(JSON.parse(localStorage.getItem('saved-irfs')));
         });
     });
 });

--- a/src/app/irf/list/irfList.service.js
+++ b/src/app/irf/list/irfList.service.js
@@ -17,6 +17,6 @@ export default class IrfListService {
     }
 
     irfExists(irfNumber) {
-        return this.service.post('irfExists/' + irfNumber);
+        return this.service.post(`data-entry/irfs/irfExists/${irfNumber}`);
     }
 }

--- a/src/app/vif/list/vifList.controller.js
+++ b/src/app/vif/list/vifList.controller.js
@@ -26,6 +26,7 @@ export default class VifListController {
             this.queryParameters.search = $stateParams.search;
         }
         this.getVifList();
+        this.checkForExistingVifs();
     }
 
     transform(queryParams) {
@@ -102,5 +103,29 @@ export default class VifListController {
         else {
             vif.confirmedDelete = true;
         }
+    }
+
+    checkForExistingVifs() {
+        var savedForLaterVifs = this.getSaveForLaterObject();
+        if (savedForLaterVifs == null) return;
+
+        savedForLaterVifs = Object.keys(savedForLaterVifs);
+        savedForLaterVifs.forEach((vifNumber) => {
+            this.service.vifExists(vifNumber).then((promise) => {
+                if (promise.data == vifNumber) {
+                    this.removeVifFromSaveForLater(vifNumber);
+                }
+            });
+        });
+    }
+
+    removeVifFromSaveForLater(vifNumber) {
+        var obj = this.getSaveForLaterObject();
+        delete obj[vifNumber];
+        localStorage.setItem('saved-vifs', JSON.stringify(obj));
+    }
+
+    getSaveForLaterObject() {
+        return JSON.parse(localStorage.getItem('saved-vifs'));
     }
 }

--- a/src/app/vif/list/vifList.controller.spec.js
+++ b/src/app/vif/list/vifList.controller.spec.js
@@ -18,7 +18,8 @@ describe('VIF List Controller',() => {
         MockVifListService = jasmine.createSpyObj('VifListService', [
             'getVifList',
             'getMoreVifs',
-            'deleteVif'
+            'deleteVif',
+            'vifExists'
         ]);
 
         let response = {'data':{
@@ -36,6 +37,14 @@ describe('VIF List Controller',() => {
             };
         });
 
+        MockVifListService.vifExists.and.callFake( () => {
+            return {
+                then: (f) => {
+                    f({data: "BHD123"});
+                }
+            };
+        });
+
         vm = new VifListController(MockVifListService, MockSessionService, $stateParams, $timeout, $window, {}, {BaseUrl: "asdf"});
     }));
 
@@ -48,6 +57,13 @@ describe('VIF List Controller',() => {
             $stateParams = {};
             vm = new VifListController(MockVifListService, MockSessionService, $stateParams, $timeout, $window, {}, {BaseUrl: "asdf"});
             expect(vm.queryParameters.search).not.toBe(null);
+        });
+
+        it('should be called with the constructor', () => {
+            spyOn(vm, 'checkForExistingVifs');
+            vm.constructor(MockVifListService, MockSessionService, $stateParams, $timeout, $window, {}, {BaseUrl: "asdf"});
+
+            expect(vm.checkForExistingVifs).toHaveBeenCalled();
         });
     });
 
@@ -160,6 +176,59 @@ describe('VIF List Controller',() => {
             vm.updateSort('rf_number');
             expect(vm.queryParameters.reverse).toBe(false);
             expect(vm.queryParameters.ordering).toBe('rf_number');
+        });
+    });
+
+    describe('function checkForExistingVifs', () => {
+        let savedVifs;
+        beforeEach(() => {
+            savedVifs = {
+                BHD123: {asdf: "asdf"},
+                BHD1234: {asdf: "asdf"}
+            }
+            localStorage.setItem('saved-vifs', JSON.stringify(savedVifs));
+        });
+
+        it('should return undefined if no saved-vifs', () => {
+            localStorage.removeItem('saved-vifs');
+            var result = vm.checkForExistingVifs();
+
+            expect(result).toEqual(undefined);
+        });
+
+        it('should call vifExists on each form in savedVifs', () => {
+            var result = vm.checkForExistingVifs();
+
+            expect(vm.service.vifExists).toHaveBeenCalledWith('BHD123');
+            expect(vm.service.vifExists).toHaveBeenCalledWith('BHD1234');
+        });
+
+        it('should call removeVifFromSaveForLater on response with same name', () => {
+            spyOn(vm, 'removeVifFromSaveForLater');
+
+            var result = vm.checkForExistingVifs();
+
+            expect(vm.removeVifFromSaveForLater).toHaveBeenCalledWith('BHD123');
+            expect(vm.removeVifFromSaveForLater).not.toHaveBeenCalledWith('BHD1234');
+        });
+    });
+
+    describe('function removeVifFromSaveForLater', () => {
+        let savedVifs;
+        beforeEach(() => {
+            savedVifs = {
+                BHD123: {asdf: "asdf"},
+                BHD1234: {asdf: "asdf"}
+            }
+            localStorage.setItem('saved-vifs', JSON.stringify(savedVifs));
+        });
+
+        it('Should remove object with passed in parameter from local storage', () => {
+            expect(savedVifs).toEqual(JSON.parse(localStorage.getItem('saved-vifs')));
+
+            vm.removeVifFromSaveForLater('BHD123');
+
+            expect(savedVifs).not.toEqual(JSON.parse(localStorage.getItem('saved-vifs')));
         });
     });
 });

--- a/src/app/vif/list/vifList.service.js
+++ b/src/app/vif/list/vifList.service.js
@@ -15,4 +15,8 @@ export default class VifListService {
     getMoreVifs(queryParameters) {
         return this.service.get('api/vif/', queryParameters);
     }
+
+    vifExists(vifNumber) {
+        return this.service.post(`data-entry/vifs/vifExists/${vifNumber}`);
+    }
 }


### PR DESCRIPTION
Clears the list on the list pages of IRF and VIF in the client. This will not work when running locally with gulp/docker-compose because they are running on separate hosts and we store these objects in localstorage, but it will work on staging and prod because they run on the same host. You can test it by setting the objects yourself and seeing them disappear when they are supposed to.

Issue connects to #79 