### PR TITLE
Adding watch capability to tests.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,9 +12,9 @@ function generateWebpackConfig() {
     return {
         files: ['test.webpack.js'],
 
-        singleRun: true,
+        singleRun: false,
 
-        autoWatch: false,
+        autoWatch: true,
 
         frameworks: ['jasmine'],
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "test": "./node_modules/karma/bin/karma start",
+    "codeshipTest": "./node_modules/karma/bin/karma start --single-run",
     "dev": "webpack-dev-server --env.dev --content-base dist/ --devtool eval --progress --colors --open",
     "local" : "rimraf ./dist/* && webpack -p --env.local",
     "stage": "rimraf ./dist/* && webpack -p --env.staging",


### PR DESCRIPTION
Fixes #158.

<h2>This should be merged quickly</h2>

All other Codeship builds will fail without this fix. Adding the watch capability means the Codeship build hangs since the tests never really complete. I had to add a new npm command and make Codeship use it.