### PR TITLE
Feature/287 angular export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 build/
 
 jsconfig.json
+npm-debug.log

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
-  "esnext": true,
+  "esversion": 6,
   "bitwise": true,
   "curly": true,
   "eqeqeq": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
-  "esversion": 6,
+  "esnext": true,
   "bitwise": true,
   "curly": true,
   "eqeqeq": true,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "angular": "1.6.3",
     "angular-animate": "1.6.3",
     "angular-cookies": "1.6.3",
+    "angular-file-saver": "1.1.3",
     "angular-float-thead": "0.1.2",
     "angular-sanitize": "1.6.3",
     "angular-touch": "1.6.3",

--- a/src/app/components/csv-export/csv-export.controller.js
+++ b/src/app/components/csv-export/csv-export.controller.js
@@ -6,6 +6,7 @@ export default class CsvExportController {
         this.getFileName = $scope.getFileName;
         this.servicefunction = $scope.exportServiceFunc;
         this.onExportComplete = $scope.onExportComplete;
+        this.onExportError = $scope.onExportError;
         this.fileDownloader = FileDownloader;
     }
 
@@ -13,6 +14,8 @@ export default class CsvExportController {
         this.servicefunction().then((resp) => {
             this.fileDownloader.downloadFileAs([resp.data], this.getFileName(), this.fileDownloader.FILE_TYPE_CSV);
             this.onExportComplete();
+        }, (err) => {
+            this.onExportError(err);
         });
     }
 }

--- a/src/app/components/csv-export/csv-export.controller.js
+++ b/src/app/components/csv-export/csv-export.controller.js
@@ -1,29 +1,18 @@
-import constants from '../../constants';
-
 export default class CsvExportController {
-    constructor($scope, $window) {
+    constructor($scope, FileDownloader) {
         'ngInject';
 
-        this.url = this.typeToUrl($scope.type);
         this.buttonText = $scope.buttontext;
-        this.window = $window;
-    }
-
-    typeToUrl(type) {
-        let url;
-        switch (type) {
-            case 'irf':
-                url = 'api/irf/export/';
-                break;
-            case 'vif':
-                url = 'api/vif/export/';
-                break;
-            default:
-        }
-        return constants.BaseUrl + url;
+        this.getFileName = $scope.getFileName;
+        this.servicefunction = $scope.exportServiceFunc;
+        this.onExportComplete = $scope.onExportComplete;
+        this.fileDownloader = FileDownloader;
     }
 
     exportCSV() {
-        this.window.open(this.url, '_blank');
+        this.servicefunction().then((resp) => {
+            this.fileDownloader.downloadFileAs([resp.data], this.getFileName(), this.fileDownloader.FILE_TYPE_CSV);
+            this.onExportComplete();
+        });
     }
 }

--- a/src/app/components/csv-export/csv-export.controller.spec.js
+++ b/src/app/components/csv-export/csv-export.controller.spec.js
@@ -8,6 +8,7 @@ describe('CsvExportController', () => {
         getFileName,
         serviceFunc,
         onExportComplete,
+        onExportError,
         mockFileDownloaderService,
         $q,
         $rootScope;
@@ -20,12 +21,14 @@ describe('CsvExportController', () => {
         getFileName = jasmine.createSpy('getFileName').and.callFake(() => fileName);
         serviceFunc = jasmine.createSpy('serviceFunc').and.callFake(() => $q.resolve(response));
         onExportComplete = jasmine.createSpy('onExportComplete');
+        onExportError = jasmine.createSpy('onExportError');
 
         $scope = {
             "buttonText": "",
             "getFileName": getFileName,
             "exportServiceFunc": serviceFunc,
-            "onExportComplete": onExportComplete
+            "onExportComplete": onExportComplete,
+            "onExportError": onExportError
         };
         mockFileDownloaderService = jasmine.createSpyObj('mockFileDownloaderService', ['downloadFileAs']);
         mockFileDownloaderService.FILE_TYPE_CSV = 'text/csv';
@@ -54,6 +57,18 @@ describe('CsvExportController', () => {
                 $rootScope.$apply();
 
                 expect(onExportComplete).toHaveBeenCalled();
+            });
+        });
+
+        describe('when service function errors', () => {
+            it('should call onExportError', () => {
+                let error = {err: 'error'};
+                serviceFunc = serviceFunc.and.callFake(() => $q.reject(error));
+
+                target.exportCSV();
+                $rootScope.$apply();
+
+                expect(onExportError).toHaveBeenCalledWith(error);
             });
         });
     });

--- a/src/app/components/csv-export/csv-export.controller.spec.js
+++ b/src/app/components/csv-export/csv-export.controller.spec.js
@@ -1,6 +1,6 @@
 import CsvExportController from './csv-export.controller';
 
-describe('MDF Controller', () => {
+describe('CsvExportController', () => {
     let target,
         $scope,
         response,
@@ -28,6 +28,7 @@ describe('MDF Controller', () => {
             "onExportComplete": onExportComplete
         };
         mockFileDownloaderService = jasmine.createSpyObj('mockFileDownloaderService', ['downloadFileAs']);
+        mockFileDownloaderService.FILE_TYPE_CSV = 'text/csv';
         target = new CsvExportController($scope, mockFileDownloaderService);
     }));
 
@@ -45,7 +46,7 @@ describe('MDF Controller', () => {
                 target.exportCSV();
                 $rootScope.$apply();
 
-                expect(mockFileDownloaderService.downloadFileAs).toHaveBeenCalledWith([response.data], fileName, 'text/csv');
+                expect(mockFileDownloaderService.downloadFileAs).toHaveBeenCalledWith([response.data], fileName, mockFileDownloaderService.FILE_TYPE_CSV);
             });
 
             it('should call onExportComplete', () => {

--- a/src/app/components/csv-export/csv-export.controller.spec.js
+++ b/src/app/components/csv-export/csv-export.controller.spec.js
@@ -1,32 +1,59 @@
 import CsvExportController from './csv-export.controller';
 
 describe('MDF Controller', () => {
-    let vm,
+    let target,
         $scope,
-        $window;
+        response,
+        fileName,
+        getFileName,
+        serviceFunc,
+        onExportComplete,
+        mockFileDownloaderService,
+        $q,
+        $rootScope;
 
-    beforeEach(inject(() => {
-        $scope = { "type": "", "buttonText": "" };
-        $window = jasmine.createSpyObj('$window', ['open']);
-        vm = new CsvExportController($scope, $window);
+    beforeEach(inject((_$q_, _$rootScope_) => {
+        $q = _$q_;
+        $rootScope = _$rootScope_;
+        response = {data: 1};
+        fileName = 'test';
+        getFileName = jasmine.createSpy('getFileName').and.callFake(() => fileName);
+        serviceFunc = jasmine.createSpy('serviceFunc').and.callFake(() => $q.resolve(response));
+        onExportComplete = jasmine.createSpy('onExportComplete');
+
+        $scope = {
+            "buttonText": "",
+            "getFileName": getFileName,
+            "exportServiceFunc": serviceFunc,
+            "onExportComplete": onExportComplete
+        };
+        mockFileDownloaderService = jasmine.createSpyObj('mockFileDownloaderService', ['downloadFileAs']);
+        target = new CsvExportController($scope, mockFileDownloaderService);
     }));
 
-    describe('function typeToUrl', () => {
-        it('expect it to create the irf url', () => {
-            var val = vm.typeToUrl('irf');
-            expect(val).toContain('irf');
-        });
-        it('expect it to create the vif url', () => {
-            var val = vm.typeToUrl('vif');
-            expect(val).toContain('vif');
-        });
-    });
+
 
     describe('exportCSV', () => {
-        it('should call window.open with url', () => {
-            vm.exportCSV();
+        it('should call service function', () => {
+            target.exportCSV();
 
-            expect($window.open).toHaveBeenCalledWith(vm.url, '_blank');
+            expect(serviceFunc).toHaveBeenCalled();
+        });
+
+        describe('when data received', () => {
+            it('should save data to file', () => {
+                target.exportCSV();
+                $rootScope.$apply();
+
+                expect(mockFileDownloaderService.downloadFileAs).toHaveBeenCalledWith([response.data], fileName, 'text/csv');
+            });
+
+            it('should call onExportComplete', () => {
+                target.exportCSV();
+                $rootScope.$apply();
+
+                expect(onExportComplete).toHaveBeenCalled();
+            });
         });
     });
 });

--- a/src/app/components/csv-export/csv-export.directive.js
+++ b/src/app/components/csv-export/csv-export.directive.js
@@ -10,8 +10,10 @@ export default function CsvExportDirective() {
         controller: CsvExportController,
         controllerAs: 'exportCtrl',
         scope: {
-            type: '@',
-            buttontext: '@'
+            buttontext: '@',
+            exportServiceFunc: '&',
+            getFileName: '&',
+            onExportComplete: '&',
         }
     };
 

--- a/src/app/components/csv-export/csv-export.directive.js
+++ b/src/app/components/csv-export/csv-export.directive.js
@@ -14,6 +14,7 @@ export default function CsvExportDirective() {
             exportServiceFunc: '&',
             getFileName: '&',
             onExportComplete: '&',
+            onExportError: '&',
         }
     };
 

--- a/src/app/irf/list/irfList.controller.js
+++ b/src/app/irf/list/irfList.controller.js
@@ -1,5 +1,5 @@
 export default class IrfListController {
-    constructor(IrfListService, SessionService, SpinnerOverlayService, StickyHeader, $state, $stateParams, $timeout,  toastr, constants, moment, $rootScope ) {
+    constructor(IrfListService, SessionService, SpinnerOverlayService, StickyHeader, $state, $stateParams, $timeout,  toastr, constants, moment) {
         'ngInject';
         this.service = IrfListService;
         this.session = SessionService;
@@ -31,12 +31,6 @@ export default class IrfListController {
         this.getIrfList();
 
         this.checkForExistingIrfs();
-
-        $rootScope.$on('$stateChangeStart', (event) => {
-            if(this.spinnerOverlayService.isVisible) {
-                event.preventDefault();
-            }
-        });
     }
 
     get hasAddPermission() {

--- a/src/app/irf/list/irfList.controller.js
+++ b/src/app/irf/list/irfList.controller.js
@@ -159,6 +159,11 @@ export default class IrfListController {
         this.spinnerOverlayService.hide();
     }
 
+    onExportError() {
+        this.toastr.error('An error occurred while exporting');
+        this.spinnerOverlayService.hide();
+    }
+
     getExportFileName() {
         let date = this.moment().format('Y-M-D');
         return `irf-all-data-${date}.csv`;

--- a/src/app/irf/list/irfList.controller.spec.js
+++ b/src/app/irf/list/irfList.controller.spec.js
@@ -3,26 +3,31 @@ import IrfListController from './irfList.controller';
 describe('IRF List Controller',() => {
     let vm,
         $timeout,
-        $window,
         MockIrfListService,
         MockSessionService,
+        MockSpinnerOverlayService,
         MockStickyHeader,
         $stateParams,
+        moment,
+        $rootScope,
         queryParameters,
         transformedQueryParameters;
 
-    beforeEach(inject((_$timeout_, _$window_) => {
-        $timeout = _$timeout_;
-        $window = _$window_;
-        $stateParams = {"search": "BHD"};
+    beforeEach(angular.mock.module('tinyhands.IRF'))
 
+    beforeEach(inject((_$timeout_, _moment_, _$rootScope_) => {
+        $timeout = _$timeout_;
+        $stateParams = {"search": "BHD"};
+        MockSessionService = { user: { } };
+        MockSpinnerOverlayService = jasmine.createSpyObj('SpinnerOverlayService', ['show', 'hide']);
         MockStickyHeader = jasmine.createSpyObj('StickyHeader', ['stickyOptions']);
 
         MockIrfListService = jasmine.createSpyObj('IrfListService', [
             'getIrfList',
             'getMoreIrfs',
             'deleteIrf',
-            'irfExists'
+            'irfExists',
+            'getCsvExport'
         ]);
 
         let response = {'data':{
@@ -48,7 +53,9 @@ describe('IRF List Controller',() => {
             };
         });
 
-        vm = new IrfListController(MockIrfListService, MockSessionService, MockStickyHeader, $stateParams, $timeout, $window, {}, {BaseUrl: "asdf"});
+        moment = _moment_;
+        $rootScope = _$rootScope_;
+        vm = new IrfListController(MockIrfListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment, $rootScope);
     }));
 
     describe('function constructor', () => {
@@ -58,14 +65,86 @@ describe('IRF List Controller',() => {
 
         it('expect the search parameter to be set', () => {
             $stateParams = {};
-            vm = new IrfListController(MockIrfListService, MockSessionService, MockStickyHeader, $stateParams, $timeout, $window, {}, {BaseUrl: "asdf"});
+            vm = new IrfListController(MockIrfListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment, $rootScope);
             expect(vm.queryParameters.search).not.toBe(null);
         });
 
         it('expect checkForExistingIrfs to be called', () => {
             spyOn(vm, 'checkForExistingIrfs');
-            vm.constructor(MockIrfListService, MockSessionService, $stateParams, $timeout, $window, {}, {BaseUrl: "asdf"});
+            vm.constructor(MockIrfListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment, $rootScope);
             expect(vm.checkForExistingIrfs).toHaveBeenCalled();
+        });
+    });
+
+    describe('hasAddPermission', () => {
+        describe('when user has irf add permission', () => {
+            it('should return true', () => {
+                MockSessionService.user.permission_irf_add = true;
+
+                expect(vm.hasAddPermission).toBe(true);
+            });
+        });
+
+        describe('when user does not have irf add permission', () => {
+            it('should return false', () => {
+                MockSessionService.user.permission_irf_add = false;
+
+                expect(vm.hasAddPermission).toBe(false);
+            });
+        });
+    });
+
+    describe('hasDeletePermission', () => {
+        describe('when user has irf delete permission', () => {
+            it('should return true', () => {
+                MockSessionService.user.permission_irf_delete = true;
+
+                expect(vm.hasDeletePermission).toBe(true);
+            });
+        });
+
+        describe('when user does not have irf delete permission', () => {
+            it('should return false', () => {
+                MockSessionService.user.permission_irf_delete = false;
+
+                expect(vm.hasDeletePermission).toBe(false);
+            });
+        });
+    });
+
+    describe('hasEditPermission', () => {
+        describe('when user has irf edit permission', () => {
+            it('should return true', () => {
+                MockSessionService.user.permission_irf_edit = true;
+
+                expect(vm.hasEditPermission).toBe(true);
+            });
+        });
+
+        describe('when user does not have irf edit permission', () => {
+            it('should return false', () => {
+                MockSessionService.user.permission_irf_edit = false;
+
+                expect(vm.hasEditPermission).toBe(false);
+            });
+        });
+    });
+
+    describe('hasViewPermission', () => {
+        describe('when user has irf view permission', () => {
+            it('should return true', () => {
+                MockSessionService.user.permission_irf_view = true;
+
+                expect(vm.hasViewPermission).toBe(true);
+            });
+        });
+
+        describe('when user does not have irf view permission', () => {
+            it('should return false', () => {
+                MockSessionService.user.permission_irf_view = false;
+
+                expect(vm.hasViewPermission).toBe(false);
+            });
         });
     });
 
@@ -231,6 +310,36 @@ describe('IRF List Controller',() => {
             vm.removeIrfFromSaveForLater('BHD123');
 
             expect(savedIrfs).not.toEqual(JSON.parse(localStorage.getItem('saved-irfs')));
+        });
+    });
+
+    describe('exportCSV', () => {
+        it('should show spinner', () => {
+            vm.exportCsv();
+
+            expect(MockSpinnerOverlayService.show).toHaveBeenCalledWith('Exporting to CSV');
+        });
+
+        it('should get CSV from service', () => {
+            vm.exportCsv();
+
+            expect(MockIrfListService.getCsvExport).toHaveBeenCalled();
+        });
+    });
+
+    describe('onExportComplete', () => {
+        it('should hide spinner', () => {
+            vm.onExportComplete();
+
+            expect(MockSpinnerOverlayService.hide).toHaveBeenCalled();
+        });
+    });
+
+    describe('getExportFileName', () => {
+        it('should return filename with date', () => {
+            let result = vm.getExportFileName();
+
+            expect(result).toBe(`irf-all-data-${moment().format('Y-M-D')}.csv`);
         });
     });
 });

--- a/src/app/irf/list/irfList.controller.spec.js
+++ b/src/app/irf/list/irfList.controller.spec.js
@@ -10,13 +10,12 @@ describe('IRF List Controller',() => {
         $state,
         $stateParams,
         moment,
-        $rootScope,
         queryParameters,
         transformedQueryParameters;
 
-    beforeEach(angular.mock.module('tinyhands.IRF'))
+    beforeEach(angular.mock.module('tinyhands.IRF'));
 
-    beforeEach(inject((_$state_, _$timeout_, _moment_, _$rootScope_) => {
+    beforeEach(inject((_$state_, _$timeout_, _moment_) => {
         $state = _$state_;
         $timeout = _$timeout_;
         $stateParams = {"search": "BHD"};
@@ -56,8 +55,7 @@ describe('IRF List Controller',() => {
         });
 
         moment = _moment_;
-        $rootScope = _$rootScope_;
-        vm = new IrfListController(MockIrfListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment, $rootScope);
+        vm = new IrfListController(MockIrfListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment);
     }));
 
     describe('function constructor', () => {
@@ -67,13 +65,13 @@ describe('IRF List Controller',() => {
 
         it('expect the search parameter to be set', () => {
             $stateParams = {};
-            vm = new IrfListController(MockIrfListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment, $rootScope);
+            vm = new IrfListController(MockIrfListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment);
             expect(vm.queryParameters.search).not.toBe(null);
         });
 
         it('expect checkForExistingIrfs to be called', () => {
             spyOn(vm, 'checkForExistingIrfs');
-            vm.constructor(MockIrfListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment, $rootScope);
+            vm.constructor(MockIrfListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment);
             expect(vm.checkForExistingIrfs).toHaveBeenCalled();
         });
     });

--- a/src/app/irf/list/irfList.controller.spec.js
+++ b/src/app/irf/list/irfList.controller.spec.js
@@ -7,6 +7,7 @@ describe('IRF List Controller',() => {
         MockSessionService,
         MockSpinnerOverlayService,
         MockStickyHeader,
+        mockToastr,
         $state,
         $stateParams,
         moment,
@@ -54,8 +55,9 @@ describe('IRF List Controller',() => {
             };
         });
 
+        mockToastr = jasmine.createSpyObj('mockToastr', ['success', 'error']);
         moment = _moment_;
-        vm = new IrfListController(MockIrfListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment);
+        vm = new IrfListController(MockIrfListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, mockToastr, {BaseUrl: "asdf"}, moment);
     }));
 
     describe('function constructor', () => {
@@ -330,6 +332,20 @@ describe('IRF List Controller',() => {
     describe('onExportComplete', () => {
         it('should hide spinner', () => {
             vm.onExportComplete();
+
+            expect(MockSpinnerOverlayService.hide).toHaveBeenCalled();
+        });
+    });
+
+    describe('onExportError', () => {
+        it('should show toastr error message', () => {
+            vm.onExportError();
+
+            expect(mockToastr.error).toHaveBeenCalledWith('An error occurred while exporting');
+        });
+
+        it('should hide spinner', () => {
+            vm.onExportError();
 
             expect(MockSpinnerOverlayService.hide).toHaveBeenCalled();
         });

--- a/src/app/irf/list/irfList.html
+++ b/src/app/irf/list/irfList.html
@@ -6,10 +6,14 @@
         </div>
 
         <div class="pull-right"><br>
-            <photoexport ng-if="irfListCtrl.session.user.permission_irf_view == true"></photoexport>
-            <csvexport type="irf" buttontext="Export All IRFs to CSV" ng-if="irfListCtrl.session.user.permission_irf_view == true"></csvexport>
-            &nbsp;
-            <a ng-if="irfListCtrl.session.user.permission_irf_add == true" class="btn btn-success pull-right" href="{{ irfListCtrl.constants.BaseUrl + '/data-entry/irfs/create/'}}">
+            <photoexport ng-if="irfListCtrl.hasViewPermission"></photoexport>
+            <csvexport buttontext="Export All IRFs to CSV"
+                       export-service-func="irfListCtrl.exportCsv()"
+                       get-file-name="irfListCtrl.getExportFileName()"
+                       on-export-complete="irfListCtrl.onExportComplete()"
+                       ng-if="irfListCtrl.hasViewPermission">
+            </csvexport>
+            <a ng-if="irfListCtrl.hasAddPermission" class="btn btn-success" href="{{ irfListCtrl.constants.BaseUrl + '/data-entry/irfs/create/'}}">
                 Input A New IRF
             </a>
         </div>
@@ -85,9 +89,9 @@
                 <td>{{ irf.date_time_of_interception | date:"medium" : irfListCtrl.timeZoneDifference }}</td>
                 <td class="hidden-xs">{{ irf.date_time_entered_into_system | date:"medium" : irfListCtrl.timeZoneDifference }}</td>
                 <td class="hidden-xs">{{ irf.date_time_last_updated | date:"medium" : irfListCtrl.timeZoneDifference }}</td>
-                <td ng-if="irfListCtrl.session.user.permission_irf_view == true"><a class="btn btn-sm btn-primary" ng-href="{{irf.view_url}}">View</a></td>
-                <td ng-if="irfListCtrl.session.user.permission_irf_edit == true"><a class="btn btn-sm btn-primary" id="id_edit_irf_button" ng-href="{{irf.edit_url}}">Edit</a></td>
-                <td ng-if="irfListCtrl.session.user.permission_irf_delete == true"><a class="btn btn-sm btn-danger" ng-click="irfListCtrl.deleteIrf(irf, $index)">
+                <td ng-if="irfListCtrl.hasViewPermission"><a class="btn btn-sm btn-primary" ng-href="{{irf.view_url}}">View</a></td>
+                <td ng-if="irfListCtrl.hasEditPermission"><a class="btn btn-sm btn-primary" id="id_edit_irf_button" ng-href="{{irf.edit_url}}">Edit</a></td>
+                <td ng-if="irfListCtrl.hasDeletePermission"><a class="btn btn-sm btn-danger" ng-click="irfListCtrl.deleteIrf(irf, $index)">
                     {{ irf.confirmedDelete ? "Confirm?" : "Delete" }}</a></td>
             </tr>
             <tr ng-show="irfListCtrl.irfs.length == 0">

--- a/src/app/irf/list/irfList.html
+++ b/src/app/irf/list/irfList.html
@@ -11,6 +11,7 @@
                        export-service-func="irfListCtrl.exportCsv()"
                        get-file-name="irfListCtrl.getExportFileName()"
                        on-export-complete="irfListCtrl.onExportComplete()"
+                       on-export-error="irfListCtrl.onExportError()"
                        ng-if="irfListCtrl.hasViewPermission">
             </csvexport>
             <a ng-if="irfListCtrl.hasAddPermission" class="btn btn-success" href="{{ irfListCtrl.constants.BaseUrl + '/data-entry/irfs/create/'}}">

--- a/src/app/irf/list/irfList.service.js
+++ b/src/app/irf/list/irfList.service.js
@@ -19,4 +19,8 @@ export default class IrfListService {
     irfExists(irfNumber) {
         return this.service.post(`data-entry/irfs/irfExists/${irfNumber}`);
     }
+
+    getCsvExport() {
+        return this.service.get('api/irf/export/');
+    }
 }

--- a/src/app/shared/directives/spinner/spinner.controller.js
+++ b/src/app/shared/directives/spinner/spinner.controller.js
@@ -1,0 +1,5 @@
+export default class SpinnerController {
+    constructor($scope) {
+        this.message = $scope.message;
+    }
+}

--- a/src/app/shared/directives/spinner/spinner.directive.js
+++ b/src/app/shared/directives/spinner/spinner.directive.js
@@ -1,0 +1,16 @@
+import './spinner.less';
+import template from './spinner.html';
+import controller from './spinner.controller';
+
+export default function SpinnerDirective() {
+    let directive = {
+        scope: {
+            message: '@'
+        },
+        controller: controller,
+        controllerAs: 'ctrl',
+        restrict: 'E',
+        templateUrl: template,
+    }
+    return directive;
+}

--- a/src/app/shared/directives/spinner/spinner.html
+++ b/src/app/shared/directives/spinner/spinner.html
@@ -1,0 +1,4 @@
+<div class="spinner-container">
+    <div class="spinner-loading"></div>
+    <p class="spinner-text">{{ctrl.message}}</p>
+</div>

--- a/src/app/shared/directives/spinner/spinner.less
+++ b/src/app/shared/directives/spinner/spinner.less
@@ -1,0 +1,23 @@
+.spinner-container {
+
+}
+
+.spinner-loading {
+  border: thick solid #f3f3f3;
+  border-top: thick solid #3498db;
+  border-radius: 50%;
+  width: 120px;
+  height: 120px;
+  animation: spin 1.5s linear infinite;
+  margin: auto;
+}
+
+.spinner-text {
+  text-align: center;
+  color: #ffffff;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/src/app/shared/directives/spinner/spinner.less
+++ b/src/app/shared/directives/spinner/spinner.less
@@ -13,6 +13,8 @@
 }
 
 .spinner-text {
+  padding: 10px;
+  font-size: x-large;
   text-align: center;
   color: #ffffff;
 }

--- a/src/app/shared/directives/spinnerOverlay/spinnerOverlay.controller.js
+++ b/src/app/shared/directives/spinnerOverlay/spinnerOverlay.controller.js
@@ -1,0 +1,14 @@
+export default class SpinnerOverlayController {
+    constructor(SpinnerOverlayService) {
+        'ngInject';
+        this.spinnerOverlayService = SpinnerOverlayService;
+    }
+
+    get isVisible() {
+        return this.spinnerOverlayService.isVisible;
+    }
+
+    get message() {
+        return this.spinnerOverlayService.message;
+    }
+}

--- a/src/app/shared/directives/spinnerOverlay/spinnerOverlay.controller.spec.js
+++ b/src/app/shared/directives/spinnerOverlay/spinnerOverlay.controller.spec.js
@@ -1,0 +1,24 @@
+import SpinnerOverlayController from './spinnerOverlay.controller';
+
+describe('SpinnerOverlayController', () => {
+    let target,
+        MockSpinnerOverlayService;
+
+    beforeEach(() => {
+        MockSpinnerOverlayService = { isVisible: true, message: 'Hi'};
+
+        target = new SpinnerOverlayController(MockSpinnerOverlayService);
+    });
+
+    describe('isVisible ', () => {
+        it('should match SpinnerOverlayService isVisible', () => {
+            expect(target.isVisible).toBe(MockSpinnerOverlayService.isVisible);
+        });
+    });
+
+    describe('isVisible ', () => {
+        it('should match SpinnerOverlayService message', () => {
+            expect(target.message).toBe(MockSpinnerOverlayService.message);
+        });
+    });
+});

--- a/src/app/shared/directives/spinnerOverlay/spinnerOverlay.directive.js
+++ b/src/app/shared/directives/spinnerOverlay/spinnerOverlay.directive.js
@@ -4,8 +4,6 @@ import controller from './spinnerOverlay.controller';
 
 export default function SpinnerOverlayDirective() {
     let directive = {
-        scope: {
-        },
         controller: controller,
         controllerAs: 'ctrl',
         restrict: 'E',

--- a/src/app/shared/directives/spinnerOverlay/spinnerOverlay.directive.js
+++ b/src/app/shared/directives/spinnerOverlay/spinnerOverlay.directive.js
@@ -1,0 +1,15 @@
+import './spinnerOverlay.less';
+import template from './spinnerOverlay.html';
+import controller from './spinnerOverlay.controller';
+
+export default function SpinnerOverlayDirective() {
+    let directive = {
+        scope: {
+        },
+        controller: controller,
+        controllerAs: 'ctrl',
+        restrict: 'E',
+        templateUrl: template,
+    }
+    return directive;
+}

--- a/src/app/shared/directives/spinnerOverlay/spinnerOverlay.html
+++ b/src/app/shared/directives/spinnerOverlay/spinnerOverlay.html
@@ -1,0 +1,3 @@
+<div class="spinner-overlay" ng-if="ctrl.isVisible">
+    <spinner message="{{ctrl.message}}"></spinner>
+</div>

--- a/src/app/shared/directives/spinnerOverlay/spinnerOverlay.less
+++ b/src/app/shared/directives/spinnerOverlay/spinnerOverlay.less
@@ -1,0 +1,15 @@
+.spinner-overlay {
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  overflow: auto;
+  z-index: 9999999999;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/app/shared/directives/spinnerOverlay/spinnerOverlay.service.js
+++ b/src/app/shared/directives/spinnerOverlay/spinnerOverlay.service.js
@@ -1,6 +1,9 @@
 export default class SpinnerOverlayService {
-    constructor() {
+    constructor($rootScope) {
         this.initState();
+
+        let onStateChangeStart = this.onStateChangeStart.bind(this);
+        $rootScope.$on('$stateChangeStart', onStateChangeStart);
     }
 
     show(message) {
@@ -15,6 +18,12 @@ export default class SpinnerOverlayService {
     initState() {
         this.isVisible = false;
         this.message = '';
+    }
+
+    onStateChangeStart(event) {
+        if(this.isVisible) {
+            event.preventDefault();
+        }
     }
 
 }

--- a/src/app/shared/directives/spinnerOverlay/spinnerOverlay.service.js
+++ b/src/app/shared/directives/spinnerOverlay/spinnerOverlay.service.js
@@ -1,0 +1,20 @@
+export default class SpinnerOverlayService {
+    constructor() {
+        this.initState();
+    }
+
+    show(message) {
+        this.isVisible = true;
+        this.message = message;
+    }
+
+    hide() {
+        this.initState();
+    }
+
+    initState() {
+        this.isVisible = false;
+        this.message = '';
+    }
+
+}

--- a/src/app/shared/directives/spinnerOverlay/spinnerOverlay.service.spec.js
+++ b/src/app/shared/directives/spinnerOverlay/spinnerOverlay.service.spec.js
@@ -4,9 +4,9 @@ describe('SpinnerOverlayService', () => {
 
     let target;
 
-    beforeEach(() => {
-        target = new SpinnerOverlayService();
-    });
+    beforeEach(inject(($rootScope) => {
+        target = new SpinnerOverlayService($rootScope);
+    }));
 
     describe('when showing', () => {
         it('should set isVisible to true', () => {
@@ -35,6 +35,34 @@ describe('SpinnerOverlayService', () => {
             target.hide();
 
             expect(target.message).toBe('');
+        });
+    });
+
+    describe('onStateChangeStart', () => {
+        let mockEvent;
+
+        beforeEach(() => {
+            mockEvent = jasmine.createSpyObj('mockEvent', ['preventDefault']);
+        });
+
+        describe('when spinner is visible', () => {
+            it('should prevent state change event', () => {
+                target.isVisible = true;
+
+                target.onStateChangeStart(mockEvent);
+
+                expect(mockEvent.preventDefault).toHaveBeenCalled();
+            });
+        });
+
+        describe('when spinner is not visible', () => {
+            it('should not prevent state change event', () => {
+                target.isVisible = false;
+
+                target.onStateChangeStart(mockEvent);
+
+                expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+            });
         });
     });
 });

--- a/src/app/shared/directives/spinnerOverlay/spinnerOverlay.service.spec.js
+++ b/src/app/shared/directives/spinnerOverlay/spinnerOverlay.service.spec.js
@@ -1,0 +1,40 @@
+import SpinnerOverlayService from './spinnerOverlay.service';
+
+describe('SpinnerOverlayService', () => {
+
+    let target;
+
+    beforeEach(() => {
+        target = new SpinnerOverlayService();
+    });
+
+    describe('when showing', () => {
+        it('should set isVisible to true', () => {
+            target.show('message');
+
+            expect(target.isVisible).toBe(true);
+        });
+
+        it('should set message to true', () => {
+            let message = 'hi';
+
+            target.show(message);
+
+            expect(target.message).toBe(message);
+        });
+    });
+
+    describe('when hiding', () => {
+        it('should set isVisible to false', () => {
+            target.hide();
+
+            expect(target.isVisible).toBe(false);
+        });
+
+        it('should clear message', () => {
+            target.hide();
+
+            expect(target.message).toBe('');
+        });
+    });
+});

--- a/src/app/shared/services/fileDownloader.service.js
+++ b/src/app/shared/services/fileDownloader.service.js
@@ -1,0 +1,14 @@
+export default class FileDownloaderService {
+    constructor(FileSaver, Blob) {
+        this.fileSaver = FileSaver;
+        this.blob = Blob;
+    }
+
+    static get FILE_TYPE_CSV() { return 'text/csv'; }
+
+    downloadFileAs(fileData, fileName, fileType) {
+        let dataArray = Array.isArray(fileData) ? fileData : [fileData];
+        let data = new this.blob(dataArray, {type: fileType});
+        this.fileSaver.saveAs(data, fileName);
+    }
+}

--- a/src/app/shared/services/fileDownloader.service.spec.js
+++ b/src/app/shared/services/fileDownloader.service.spec.js
@@ -1,0 +1,39 @@
+import FileDownloaderService from './fileDownloader.service';
+
+describe('FileDownloaderService', () => {
+    let target,
+        blob,
+        mockBlob,
+        mockFileSaver;
+
+    beforeEach(() => {
+        blob = (data, options) => {
+            return { data: data, type: options.type };
+        };
+        mockBlob = jasmine.createSpy('mockBlob', blob).and.callFake(blob);
+
+        mockFileSaver = jasmine.createSpyObj('mockFileSaver', ['saveAs']);
+        target = new FileDownloaderService(mockFileSaver, mockBlob);
+
+    });
+
+    describe('downloadFileAs', () => {
+        it('should create blob with data array and fileType', () => {
+            let data = 1;
+            let fileType = 'csv';
+            target.downloadFileAs(data, 'name', fileType);
+            expect(mockBlob).toHaveBeenCalledWith([data], {type: fileType});
+        });
+
+        it('should save blob to file', () => {
+            let data = 1;
+            let fileType = 'csv';
+            let fileName = 'hello';
+            let expectedBlobData = blob([data], {type: fileType});
+
+            target.downloadFileAs(data, fileName, fileType);
+
+            expect(mockFileSaver.saveAs).toHaveBeenCalledWith(expectedBlobData, fileName);
+        });
+    });
+});

--- a/src/app/shared/shared.module.js
+++ b/src/app/shared/shared.module.js
@@ -2,21 +2,26 @@ import 'floatthead';
 import 'angular-float-thead';
 import moment from 'moment';
 import 'moment-timezone';
+import ngFileSaver from 'angular-file-saver';
 import toastr from 'toastr';
 import 'angular-ui-validate';
 
 import config from './shared.config';
 
 import BaseService from '../base.service';
+import FileDownloaderServie from './services/fileDownloader.service';
 import SessionService from './services/session.service';
+import SpinnerOverlayService from './directives/spinnerOverlay/spinnerOverlay.service';
 import StickyHeaderService from './services/stickyHeader.service';
 import UtilService from './services/util.service';
 import RequireLogin from './requireLogin';
 import PermissionsRequired from './permissionsRequired';
 
 import ConfirmButton from './directives/confirmButton/confirmButton.directive';
+import Spinner from './directives/spinner/spinner.directive';
+import SpinnerOverlay from './directives/spinnerOverlay/spinnerOverlay.directive';
 
-export default angular.module('tinyhands.Shared', ['floatThead', 'ui.validate'])
+export default angular.module('tinyhands.Shared', [ngFileSaver, 'floatThead', 'ui.validate'])
     .filter('capitalize', function () {
         return function (input) {
             return (!!input) ? input.charAt(0).toUpperCase() + input.substr(1).toLowerCase() : '';
@@ -27,13 +32,16 @@ export default angular.module('tinyhands.Shared', ['floatThead', 'ui.validate'])
     .constant('toastr', toastr)
     .constant('moment', moment)
 
-    .service('StickyHeader', StickyHeaderService)
-
     .service('BaseService', BaseService)
+    .service('FileDownloader', FileDownloaderServie)
     .service('SessionService', SessionService)
+    .service('SpinnerOverlayService', SpinnerOverlayService)
+    .service('StickyHeader', StickyHeaderService)
     .service('UtilService', UtilService)
 
     .directive('confirmButton', ConfirmButton)
+    .directive('spinner', Spinner)
+    .directive('spinnerOverlay', SpinnerOverlay)
     
     .run(PermissionsRequired)
     .name;

--- a/src/app/vif/list/vifList.controller.js
+++ b/src/app/vif/list/vifList.controller.js
@@ -158,6 +158,11 @@ export default class VifListController {
         this.spinnerOverlayService.hide();
     }
 
+    onExportError() {
+        this.toastr.error('An error occurred while exporting');
+        this.spinnerOverlayService.hide();
+    }
+
     getExportFileName() {
         let date = this.moment().format('Y-M-D');
         return `vif-all-data-${date}.csv`;

--- a/src/app/vif/list/vifList.controller.js
+++ b/src/app/vif/list/vifList.controller.js
@@ -1,5 +1,5 @@
 export default class VifListController {
-    constructor(VifListService, SessionService, SpinnerOverlayService, StickyHeader, $state, $stateParams, $timeout, toastr, constants, moment, $rootScope) {
+    constructor(VifListService, SessionService, SpinnerOverlayService, StickyHeader, $state, $stateParams, $timeout, toastr, constants, moment) {
         'ngInject';
 
         this.constants = constants;
@@ -30,12 +30,6 @@ export default class VifListController {
         }
         this.getVifList();
         this.checkForExistingVifs();
-
-        $rootScope.$on('$stateChangeStart', (event) => {
-            if(this.spinnerOverlayService.isVisible) {
-                event.preventDefault();
-            }
-        });
     }
 
     get hasAddPermission() {

--- a/src/app/vif/list/vifList.controller.spec.js
+++ b/src/app/vif/list/vifList.controller.spec.js
@@ -7,6 +7,7 @@ describe('VIF List Controller',() => {
         MockSessionService,
         MockSpinnerOverlayService,
         MockStickyHeader,
+        mockToastr,
         $state,
         $stateParams,
         queryParameters,
@@ -55,7 +56,9 @@ describe('VIF List Controller',() => {
             };
         });
 
-        vm = new VifListController(MockVifListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment);
+        mockToastr = jasmine.createSpyObj('mockToastr', ['success', 'error']);
+
+        vm = new VifListController(MockVifListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, mockToastr, {BaseUrl: "asdf"}, moment);
     }));
 
     describe('function constructor', () => {
@@ -331,6 +334,20 @@ describe('VIF List Controller',() => {
     describe('onExportComplete', () => {
         it('should hide spinner', () => {
             vm.onExportComplete();
+
+            expect(MockSpinnerOverlayService.hide).toHaveBeenCalled();
+        });
+    });
+
+    describe('onExportError', () => {
+        it('should show toastr error message', () => {
+            vm.onExportError();
+
+            expect(mockToastr.error).toHaveBeenCalledWith('An error occurred while exporting');
+        });
+
+        it('should hide spinner', () => {
+            vm.onExportError();
 
             expect(MockSpinnerOverlayService.hide).toHaveBeenCalled();
         });

--- a/src/app/vif/list/vifList.controller.spec.js
+++ b/src/app/vif/list/vifList.controller.spec.js
@@ -11,17 +11,15 @@ describe('VIF List Controller',() => {
         $stateParams,
         queryParameters,
         transformedQueryParameters,
-        moment,
-        $rootScope;
+        moment;
 
     beforeEach(angular.mock.module('tinyhands.VIF'));
 
-    beforeEach(inject((_$state_, _$timeout_, _moment_, _$rootScope_) => {
+    beforeEach(inject((_$state_, _$timeout_, _moment_) => {
         $state = _$state_;
         $timeout = _$timeout_;
         $stateParams = {"search": "BHD"};
         moment = _moment_;
-        $rootScope = _$rootScope_;
         MockSessionService = { user: { } };
         MockSpinnerOverlayService = jasmine.createSpyObj('SpinnerOverlayService', ['show', 'hide']);
         MockStickyHeader = jasmine.createSpyObj('StickyHeader', ['stickyOptions']);
@@ -57,7 +55,7 @@ describe('VIF List Controller',() => {
             };
         });
 
-        vm = new VifListController(MockVifListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment, $rootScope);
+        vm = new VifListController(MockVifListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment);
     }));
 
     describe('function constructor', () => {
@@ -67,13 +65,13 @@ describe('VIF List Controller',() => {
 
         it('expect the search parameter to be set', () => {
             $stateParams = {};
-            vm = new VifListController(MockVifListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment, $rootScope);
+            vm = new VifListController(MockVifListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment);
             expect(vm.queryParameters.search).not.toBe(null);
         });
 
         it('should be called with the constructor', () => {
             spyOn(vm, 'checkForExistingVifs');
-            vm.constructor(MockVifListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment, $rootScope);
+            vm.constructor(MockVifListService, MockSessionService, MockSpinnerOverlayService, MockStickyHeader, $state, $stateParams, $timeout, {}, {BaseUrl: "asdf"}, moment);
 
             expect(vm.checkForExistingVifs).toHaveBeenCalled();
         });
@@ -303,7 +301,7 @@ describe('VIF List Controller',() => {
             savedVifs = {
                 BHD123: {asdf: "asdf"},
                 BHD1234: {asdf: "asdf"}
-            }
+            };
             localStorage.setItem('saved-vifs', JSON.stringify(savedVifs));
         });
 

--- a/src/app/vif/list/vifList.html
+++ b/src/app/vif/list/vifList.html
@@ -10,6 +10,7 @@
                        export-service-func="vifListCtrl.exportCsv()"
                        get-file-name="vifListCtrl.getExportFileName()"
                        on-export-complete="vifListCtrl.onExportComplete()"
+                       on-export-error="vifListCtrl.onExportError()"
                        ng-if="vifListCtrl.hasViewPermission">
             </csvexport>
             &nbsp;

--- a/src/app/vif/list/vifList.html
+++ b/src/app/vif/list/vifList.html
@@ -6,9 +6,14 @@
         </div>
 
         <div class="pull-right"><br>
-            <csvexport type="vif" buttontext="Export All VIFs to CSV" ng-if="vifListCtrl.session.user.permission_vif_view == true"></csvexport>
+            <csvexport buttontext="Export All VIFs to CSV"
+                       export-service-func="vifListCtrl.exportCsv()"
+                       get-file-name="vifListCtrl.getExportFileName()"
+                       on-export-complete="vifListCtrl.onExportComplete()"
+                       ng-if="vifListCtrl.hasViewPermission">
+            </csvexport>
             &nbsp;
-            <a ng-if="vifListCtrl.session.user.permission_vif_add == true" class="btn btn-success pull-right" href="{{vifListCtrl.constants.BaseUrl + 'data-entry/vifs/create/'}}">
+            <a ng-if="vifListCtrl.hasAddPermission" class="btn btn-success pull-right" href="{{vifListCtrl.constants.BaseUrl + 'data-entry/vifs/create/'}}">
                 Input A New VIF
             </a>
         </div>
@@ -84,9 +89,9 @@
                 <td>{{ vif.date | date:"medium" : vifListCtrl.timeZoneDifference }}</td>
                 <td class="hidden-xs">{{ vif.date_time_entered_into_system | date:"medium" : vifListCtrl.timeZoneDifference }}</td>
                 <td class="hidden-xs">{{ vif.date_time_last_updated | date:"medium" : vifListCtrl.timeZoneDifference }}</td>
-                <td ng-if="vifListCtrl.session.user.permission_vif_view == true"><a class="btn btn-sm btn-primary" ng-href="{{vif.view_url}}">View</a></td>
-                <td ng-if="vifListCtrl.session.user.permission_vif_edit == true"><a class="btn btn-sm btn-primary" id="id_edit_vif_button" ng-href="{{vif.edit_url}}">Edit</a></td>
-                <td ng-if="vifListCtrl.session.user.permission_vif_delete == true"><a class="btn btn-sm btn-danger" ng-click="vifListCtrl.deleteVif(vif, $index)">
+                <td ng-if="vifListCtrl.hasViewPermission"><a class="btn btn-sm btn-primary" ng-href="{{vif.view_url}}">View</a></td>
+                <td ng-if="vifListCtrl.hasEditPermission"><a class="btn btn-sm btn-primary" id="id_edit_vif_button" ng-href="{{vif.edit_url}}">Edit</a></td>
+                <td ng-if="vifListCtrl.hasDeletePermission"><a class="btn btn-sm btn-danger" ng-click="vifListCtrl.deleteVif(vif, $index)">
                     {{ vif.confirmedDelete ? "Confirm?" : "Delete" }}</a></td>
             </tr>
             <tr ng-show="vifListCtrl.vifs.length == 0">

--- a/src/app/vif/list/vifList.service.js
+++ b/src/app/vif/list/vifList.service.js
@@ -19,4 +19,8 @@ export default class VifListService {
     vifExists(vifNumber) {
         return this.service.post(`data-entry/vifs/vifExists/${vifNumber}`);
     }
+
+    getCsvExport() {
+        return this.service.get('api/vif/export/');
+    }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,8 @@
     <!--[if lt IE 10]>
       <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->
+    <spinner-overlay></spinner-overlay>
+
     <navbar></navbar>
 
     <div id="main-container" class="full-height" ui-view></div>


### PR DESCRIPTION
Angular now handles exporting of IRF and VIF csv, requiring only being logged in on the frontend.

- Added npm-debug.log to gitignore
- Changed es version in jshintrc for editors that support it
- Added angular filesaver library
- Changed csvexport directive to use filesaver
- Refactored VIF and IRF list permission code to get some js out of html
- Updated VIF and IRF export code to use new csvexport directive
- Added spinner directive to use when user is waiting for something
- Added spinneroverlay service which shows spinner and message over screen contents. Service controls when it is shown and hidden
- Tests

Connects to Tiny-Hands/tinyhands#287