### PR TITLE
Fix issues with ID Management:

### DIFF
--- a/src/app/idmanagement/idmanagement.html
+++ b/src/app/idmanagement/idmanagement.html
@@ -11,7 +11,7 @@
 	            <p style="margin-top: 5px;">Results per page</p>
 	        </div>
 	        <div class="pull-right">
-	            <form ng-submit="vm.addGroupSearch()">
+	            <form>
 	                  <label>
 	                      <input type="search" placeholder="Person name..." ng-model="vm.searchValue" class="form-control">
 	                  </label>
@@ -23,7 +23,7 @@
 	    <table class="table table-striped" float-thead="vm.stickyOptions" cellspacing="0" cellpadding="0" cellborder="0" style="border-collapse:collapse;" >
 	        <thead class="sticky-table-header">
 	            <tr>
-	                <th id="knownPersonNameHeader" ng-click="vm.sortColumn = 'name'; vm.reverse = ! vm.reverse; vm.getKnownPersons()" class="text-center" width="12%">
+	                <th id="knownPersonNameHeader" ng-click="vm.sortColumn = 'full_name'; vm.reverse = ! vm.reverse; vm.getKnownPersons()" class="text-center" width="12%">
 	                	Name<i class="glyphicon" ng-class="vm.sortIcon('name')"></i>
 	                </th>
 	                <th id="knownPersonGenderHeader" ng-click="vm.sortColumn = 'gender'; vm.reverse = ! vm.reverse; vm.getKnownPersons()" class="text-center" width="8%">
@@ -32,13 +32,13 @@
 	                <th id="knownPersonAgeHeader" ng-click="vm.sortColumn = 'age'; vm.reverse = ! vm.reverse; vm.getKnownPersons()" class="text-center" width="6%">
 	                    Age<i class="glyphicon" ng-class="vm.sortIcon('age')"></i>
 	                </th>
-	                <th id="knownPersonAddress1Header" ng-click="vm.sortColumn = 'address1'; vm.reverse = ! vm.reverse; vm.getKnownPersons()" class="text-center" width="11%">
+	                <th id="knownPersonAddress1Header" ng-click="vm.sortColumn = 'address1.name'; vm.reverse = ! vm.reverse; vm.getKnownPersons()" class="text-center" width="11%">
 	                    Address 1<i class="glyphicon" ng-class="vm.sortIcon('address1')"></i>
 	                </th>
-	                <th id="knownPersonAddress2Header" ng-click="vm.sortColumn = 'address2'; vm.reverse = ! vm.reverse; vm.getKnownPersons()" class="text-center" width="11%">
+	                <th id="knownPersonAddress2Header" ng-click="vm.sortColumn = 'address2.name'; vm.reverse = ! vm.reverse; vm.getKnownPersons()" class="text-center" width="11%">
 	                    Address 2<i class="glyphicon" ng-class="vm.sortIcon('address2')"></i>
 	                </th>
-	                <th id="knownPersonPhoneHeader" ng-click="vm.sortColumn = 'phone'; vm.reverse = ! vm.reverse; vm.getKnownPersons()" class="text-center" width="10%">
+	                <th id="knownPersonPhoneHeader" ng-click="vm.sortColumn = 'phone_contact'; vm.reverse = ! vm.reverse; vm.getKnownPersons()" class="text-center" width="10%">
 	                    Phone <i class="glyphicon" ng-class="vm.sortIcon('phone')"></i>
 	                </th>
 	                <th id="knownPersonFormKindHeader" class="text-center" width="8%">
@@ -80,8 +80,15 @@
 	
 	    <div class="row text-center">
 	        <button ng-disabled="!vm.nextPageUrl" ng-click="vm.loadMoreKnownPersons()" class="btn btn-primary" style="margin-bottom:25px; width:90%;">Load more results</button>
+	        <br/>
+	        <br/>
+	        <br/>
+	        <br/>
+	        <br/>
+	        <br/>
+	        <br/>
+	        <br/>
 	    </div>
-	
 
 	</div>
 	<div ng-show="vm.showAddAlias || vm.showRemoveAlias">


### PR DESCRIPTION
- when I scroll to the bottom of a page the screen gets jumpy like it's trying to scroll down further
- when I tried to use the search feature in the main ID Management page it worked some of the time but other times the thing would keep spinning and never found anything after several minutes. I noticed that if I clicked the sort by name header while it was stuck searching it would sometimes all of a sudden bring up the correct results.
- when sorting with different headers it seemed in some cases to only be sorting the data on that first page, and in others to be sorting additional data that wasn't initially visible (for example, in sorting names either a-z or z-a all of the resulting names started with "a," but when sorting by age names starting with other letters appeared).

Connects to #192 