### PR TITLE
Change back to walking to border

### DIFF
--- a/src/app/irf/nepal/step-templates/signs.html
+++ b/src/app/irf/nepal/step-templates/signs.html
@@ -83,7 +83,7 @@
                         <hr/>
                         <div class="col-md-6">
                             <form-step type="checkbox" label="Waiting / sitting" response-value="$ctrl.questions[124].response.value"></form-step>
-                            <form-step type="checkbox" label="On a train" response-value="$ctrl.questions[135].response.value"></form-step>
+                            <form-step type="checkbox" label="Walking to border" response-value="$ctrl.questions[135].response.value"></form-step>
                             <form-step type="checkbox" label="Roaming around" response-value="$ctrl.questions[126].response.value"></form-step>
                             <form-step type="checkbox" label="Exiting vehicle" response-value="$ctrl.questions[127].response.value"></form-step>
                             <form-step type="checkbox" label="Heading to vehicle" response-value="$ctrl.questions[128].response.value"></form-step>


### PR DESCRIPTION
Changes included:
* Evidently, removing "walking to border" was a mistake and they wanted that flag back
* Added it back into questionlayout and added migration that sets the flag based on the old IRFs.
* Also, I apparently never added "on a train" to the sanitized data, nor did I put its question id in the client