### PR TITLE
Changed ng-if to ng-show in autocomplete-address2.html

### DIFF
--- a/src/app/components/auto-complete/address2/autocomplete-address2.html
+++ b/src/app/components/auto-complete/address2/autocomplete-address2.html
@@ -5,7 +5,7 @@
   <i ng-show="loadingAddress2" class="glyphicon glyphicon-refresh"></i>
 
   <div class="row">
-  	<div ng-if="!acAddress2Ctrl.$scope.address1Object || acAddress2Ctrl.$scope.address1Object.name" class="col-md-10">
+  	<div ng-show="!acAddress2Ctrl.$scope.address1Object || acAddress2Ctrl.$scope.address1Object.name" class="col-md-10">
       <input name="address2Entry" class="form-control" type="text" ng-model="ngModel" placeholder="Address 2" uib-typeahead="address2 as address2.name for address2 in acAddress2Ctrl.getFuzzyAddress2s($viewValue)"
         typeahead-loading="loadingAddress2" uib-typeahead-no-results="noResults" typeahead-wait-ms="300" typeahead-min-length="3"
       />


### PR DESCRIPTION
Not sure exactly why this was not working.
The address2 input was enclosed within a div that was conditionally
included using an ng-if.  The address2 input visually appeared to be
working, but the selected value was not being stored in the model.
Replacing the ng-if in the div with an ng-show resolved the problem.
It appears that the input is not being initialized correctly when the
page is initially displayed (the address1Object.name is initially null).

Connects to #

Changes included:
*
*
*
