### PR TITLE
Fixed mapNewStaffSalaries in the budget.controller.js

### DIFF
--- a/src/app/budget/form/budget.controller.js
+++ b/src/app/budget/form/budget.controller.js
@@ -503,7 +503,7 @@ export default class BudgetController {
                     staff.salaryInfo = $.grep(staffSalaries, s => {
                         return s.staff_person === staff.id;
                     })[0];
-                    if (staff.salaryInfo === null) {
+                    if (!staff.salaryInfo) {
                         staff.salaryInfo = {
                             salary: 0,
                             staff_person: staff.id,
@@ -511,7 +511,10 @@ export default class BudgetController {
                     }
                 }
             } else {
-                staff.salaryInfo = { salary: 0 };
+                staff.salaryInfo = {
+                    salary: 0,
+                    staff_person: staff.id,
+                };
             }
             staff.salaryInfo.id = null;
         });


### PR DESCRIPTION
Problem occurred when a new staff was added.  An exception was thrown
when processing a staff member for which prior salary information did
not exist.  The salary information was not properly populated for that
staff member and any subsequent staff members.

Connects to #355 

Changes included:
*
*
*
