### PR TITLE
Update dateData.js to work with all timezones and browsers.

### DIFF
--- a/src/app/cif/nepal/step-templates/legal.html
+++ b/src/app/cif/nepal/step-templates/legal.html
@@ -48,7 +48,7 @@
     	<br>
     	<form-step class="control-label col-md-2">4.6 Date of visit to Police Station</form-step>
     	<div class="col-md-2">
-    		<input type="date" class="col-md-12" ng-model="$ctrl.dateData.questions[375].value">
+    		<input type="date" class="col-md-12"  ng-model-options="{timezone: 'utc'}" ng-model="$ctrl.dateData.questions[375].value">
     	</div>
     	<form-step class="control-label col-md-2">4.7 Name of Officer</form-step>
     	<div class="col-md-3">
@@ -85,7 +85,7 @@
     	</div>
     	<form-step class="control-label col-md-1">4.11 Date</form-step>
     	<div class="col-md-2">
-    		<input type="date" class="col-md-12" ng-model="$ctrl.dateData.questions[386].value">
+    		<input type="date" class="col-md-12" ng-model-options="{timezone: 'utc'}" ng-model="$ctrl.dateData.questions[386].value">
     	</div>
  	</div>
  	<div class="row">

--- a/src/app/cif/nepal/step-templates/locationBoxes/locationBoxModal.html
+++ b/src/app/cif/nepal/step-templates/locationBoxes/locationBoxModal.html
@@ -108,7 +108,7 @@
 			</div>
 			<div class="row col-md-12">
             	<label>Starting From:</label>
-            	<input type="date" ng-model="LocationBoxModalController.questions[437].response.value">
+            	<input type="date" ng-model-options="{timezone: 'utc'}" ng-model="LocationBoxModalController.dateData.questions[437].value">
             </div>
             <div class="row col-md-12">
             	<label>Was there any attempt made to hide the PV's presence at this place?</label>&nbsp;

--- a/src/app/dateData.js
+++ b/src/app/dateData.js
@@ -4,6 +4,15 @@ class DateData {
 		this.questions = {};
 	}
 	
+	dateAsUTC(inDateString) {
+	    let parts = inDateString.split("-");
+	    let year = Number(parts[0]);
+	    let month = Number(parts[1]) - 1;
+	    let date = Number(parts[2]);
+	    let utcDate = new Date(Date.UTC(year, month, date, 0, 0, 0, 0));
+	    return utcDate;
+	}
+	
 	setDate(questionId, dateType) {
 		if (dateType === 'basic') {
 			let value = '';
@@ -13,14 +22,14 @@ class DateData {
 			}
 			let dateValue = '';
 			if (value !== null && value !== '') {
-				dateValue = new Date(value);
+				dateValue = this.dateAsUTC(value);
 			}
 			this.questions[questionId] = {dateType:dateType, value:dateValue};
 		} else if (dateType === 'person') {
 			let bdate = this.origQuestions[questionId].response.birthdate;
 			let dateValue = '';
-			if (bdate !== undefined && bdate !== null && bdate.value !== null && bdate.value !== '') {
-				dateValue = new Date(bdate.value);
+			if (bdate && bdate.value) {
+				dateValue = this.dateAsUTC(bdate.value);
 			}
 			this.questions[questionId] = {dateType:dateType, value:dateValue};
 		}

--- a/src/app/irf/africa/step-templates/interceptees/intercepteeModal.html
+++ b/src/app/irf/africa/step-templates/interceptees/intercepteeModal.html
@@ -50,7 +50,7 @@
                 <div class="col-md-6 form-group margin-top-15">
                     <label class="col-md-3 control-label">Date of Birth</label>
                     <div class="col-md-9">
-                        <input type="date" class="form-control" ng-model="IntercepteeModalController.dateData.questions[9].value">
+                        <input type="date" class="form-control" ng-model-options="{timezone: 'utc'}" ng-model="IntercepteeModalController.dateData.questions[9].value">
                     </div>
                 </div>
             </div>

--- a/src/app/irf/malawi/step-templates/interceptees/intercepteeModal.html
+++ b/src/app/irf/malawi/step-templates/interceptees/intercepteeModal.html
@@ -50,7 +50,7 @@
                 <div class="col-md-6 form-group margin-top-15">
                     <label class="col-md-3 control-label">Date of Birth</label>
                     <div class="col-md-9">
-                        <input type="date" class="form-control" ng-model="IntercepteeModalController.dateData.questions[9].value">
+                        <input type="date" class="form-control" ng-model-options="{timezone: 'utc'}" ng-model="IntercepteeModalController.dateData.questions[9].value">
                     </div>
                 </div>
             </div>

--- a/src/app/irf/south-africa/step-templates/interceptees/intercepteeModal.html
+++ b/src/app/irf/south-africa/step-templates/interceptees/intercepteeModal.html
@@ -50,7 +50,7 @@
                 <div class="col-md-6 form-group margin-top-15">
                     <label class="col-md-3 control-label">Date of Birth</label>
                     <div class="col-md-9">
-                        <input type="date" class="form-control" ng-model="IntercepteeModalController.dateData.questions[9].value">
+                        <input type="date" class="form-control" ng-model-options="{timezone: 'utc'}" ng-model="IntercepteeModalController.dateData.questions[9].value">
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
With Firefox, the Date constructor that takes a sting date creates the date for midnight UTC (GMT).
With Chrome and Edge, the Date construct that takes a string date creates the date for mightning local time.
Updated the DateData class to create the date at midnight UTC
Update html for date input that did not specify UTC time zone.

Connects to #

Changes included:
*
*
*
