### PR TITLE
Make copy of date/time object before subtracting time zone offset.

### DIFF
--- a/src/app/irf/irf.service.js
+++ b/src/app/irf/irf.service.js
@@ -128,8 +128,10 @@ export default class IrfService {
     		if (t1 > -1) {
     			let dt = irf.responses[idx].response.value;
 	    		if (dt instanceof  Date) {
+	    		        let dtCopy = new Date(dt.getTime());
 	    			let tzo = dt.getTimezoneOffset();
-	    			dt.setMinutes(dt.getMinutes() - tzo);
+	    			dtCopy.setMinutes(dtCopy.getMinutes() - tzo);
+	    			irf.responses[idx].response.value = dtCopy;
 	    		}
     		}
     	}


### PR DESCRIPTION
This will avoid subtracting the time zone offset when a submit fails due to error or warning.

Connects to #475 

Changes included:
*
*
*
