### PR TITLE
The forms section of the border station was conditionally included based

### DIFF
--- a/src/app/border-station/borderStation.html
+++ b/src/app/border-station/borderStation.html
@@ -16,7 +16,7 @@
 			<border-station-detail></border-station-detail>
 			<border-station-person></border-station-person>
 			<border-station-location></border-station-location>
-			<border-station-form ng-if="bsCtrl.session.checkPermission('STATIONS','SET_FORMS',null, null)"></border-station-form>
+			<border-station-form ng-show="bsCtrl.session.checkPermission('STATIONS','SET_FORMS',null, null)"></border-station-form>
 
 			<!-- REGION: Block for error messages -->
 			<div class="text-danger well" ng-if="bsCtrl.errors.length > 0">

--- a/src/app/shared/services/session.service.js
+++ b/src/app/shared/services/session.service.js
@@ -44,7 +44,7 @@ export default class SessionService {
             if (this.permissions.length < 1) {
                 this.getPermissions();
             }
-            if (typeof this.user !== 'undefined') {
+            if (typeof this.user !== 'undefined' && this.userPermissions.length < 1) {
                 this.getUserPermissions();
             }       
             return this.user;


### PR DESCRIPTION
on permissions.  This conditional inclusion seems to have impacted the
form controller registration for events.  Changing the conditional from
ng-if to ng-show resolved the issue of saving the forms when creating a
border station.
The border station fields not being editable would appear to be a timing
issue with the retrieval of permissions from the server.  The code has
been updated to reduce the number of permission requests to the server
which should make the timing issue much more rare.

Connects to #493 

Changes included:
*
*
*
