### PR TITLE
Fix sending of MDF emails to work with both old and new versions

### DIFF
--- a/src/app/budget/mdf/mdf.controller.js
+++ b/src/app/budget/mdf/mdf.controller.js
@@ -56,6 +56,7 @@ export default class MdfController {
         people = this.getIds(this.committeeMembers, people, "committee_ids");
         people = this.getIds(this.nationalStaff, people, "national_staff_ids");
         people.budget_id = this.stateParams.id;
+        people.mdf_type = this.mdfType;
 
         this.service.sendMdfEmails(people).then(() => {
             this.toastr.success(`Successfully emailed the MDF`);

--- a/src/app/project-request/reviewProjectRequest.html
+++ b/src/app/project-request/reviewProjectRequest.html
@@ -113,7 +113,7 @@
 			<button class="btn btn-warning" ng-if="$ctrl.canModifyApproved || $ctrl.canApprove" ng-click="$ctrl.changeApprovedAmount()">Change Approved Amount</button>
 		</div>
 		<div class="col-md-4 text-right">
-			<button class="btn btn-danger" ng-if="$ctrl.projectRequest.status==='Submitted'&&($ctrl.canApprove || $ctrl.isAuthor)" ng-click="$ctrl.deleteRequest()">Delete</button>
+			<button class="btn btn-danger" ng-if="!$ctrl.projectRequest.approved_mdf && $ctrl.canUpdate" ng-click="$ctrl.deleteRequest()">Delete</button>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Allow project requests to be deleted if they are not already on fully approved MDFs.

Connects to #1293 

Changes included:
*
*
*
